### PR TITLE
Update __init__.py

### DIFF
--- a/custom_components/renfrew_bridge/__init__.py
+++ b/custom_components/renfrew_bridge/__init__.py
@@ -3,7 +3,7 @@ from .const import DOMAIN
 async def async_setup_entry(hass, entry):
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = entry.data
-    hass.async_create_task(hass.config_entries.async_forward_entry_setup(entry, "sensor"))
+    await hass.config_entries.async_forward_entry_setups(entry, ["sensor"])
     return True
 
 async def async_unload_entry(hass, entry):


### PR DESCRIPTION
async_forward_entry_setup is deprecated in Home Assistant 2025.6